### PR TITLE
bump ssh-key to 0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9b366a80cf18bb6406f4cf4d10aebfb46140a8c0c33f666a144c5c76ecbafc"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
  "ed25519-dalek",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshauth"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "SSH key based (agents or static files) authentication tokens"
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 sha2 = "0.10.8"
 slog = "2.7"
 ssh-encoding = "0.2"
-ssh-key = { version = "0.6.4", features = ["p256", "ed25519"] }
+ssh-key = { version = "0.6.7", features = ["p256", "ed25519"] }
 tokio = { version = "1", features = ["io-util", "net"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This brings in fixes RustCrypto/SSH#291 and RustCrypto/SSH#289